### PR TITLE
Make sure pip command is coming from pyenv

### DIFF
--- a/bin/pyenv-pip-upgrade
+++ b/bin/pyenv-pip-upgrade
@@ -37,6 +37,14 @@ function __msg_info () {
   printf '\e[1;33m[INFO]: %s\n\e[0m' "${1}"
 }
 
+function __pip () {
+  pyenv exec pip ${@}
+}
+
+function __conda () {
+  pyenv exec conda ${@}
+}
+
 function elementIn () {
   local elem="$1"   # Save first argument in a variable
   shift            # Shift all arguments to the left (original $1 gets lost)
@@ -52,18 +60,18 @@ function pip_upgrade_packages () {
   local outdated_packages=()
   while IFS='' read -r line; do 
     outdated_packages+=("$line"); 
-  done < <(pip list --outdated --format=freeze 2>/dev/null | grep -v '^\-e' | cut -d = -f 1)
+  done < <(__pip list --outdated --format=freeze 2>/dev/null | grep -v '^-e' | cut -d = -f 1)
   if [[ ${#outdated_packages[@]} -eq 0 ]]; then
     __msg_info "Nothing to update in this environment..."
     return
   fi
   if [[ "$strategy" == "serial" ]]; then
     __msg_info "Updating packages: $(IFS=$' '; echo "${outdated_packages[*]}")"
-    pip install --upgrade "${outdated_packages[@]}"
+    __pip install --upgrade "${outdated_packages[@]}"
   elif [[ "$strategy" == "sequential" ]]; then
     for pck in "${outdated_packages[@]}"; do
       __msg_info "Updating package $pck..."
-      pip install --upgrade "$pck"
+      __pip install --upgrade "$pck"
     done
   fi
 }
@@ -144,12 +152,12 @@ for pyenv_to_update in "${pyenvs_to_update[@]}"; do
 
   # So as in conda environments pip is also available we check if this is a
   # conda environment at first.
-  if conda >/dev/null 2>&1; then
+  if __conda >/dev/null 2>&1; then
       __msg_info "Updating conda environment: ${pyenv_to_update}..."
-      conda update --all -y
+      __conda update --all -y
       # in conda there could be packages installed with pip
       pip_upgrade_packages
-  elif pip >/dev/null 2>&1; then
+  elif __pip >/dev/null 2>&1; then
        __msg_info "Updating pip environment: ${pyenv_to_update}..."
        pip_upgrade_packages
   else

--- a/bin/pyenv-pip-upgrade
+++ b/bin/pyenv-pip-upgrade
@@ -5,22 +5,22 @@
 # Usage: pyenv pip-upgrade [OPTIONS] <pyenv_env1> [<pyenv_env2> ...]
 #        pyenv pip-upgrade [OPTIONS] --all
 #
-# This command update all packages to the latest versions of particular or all 
-# pyenv environments excluding system. By default, pip-upgrade update all 
-# outdated packages of an environment at once. New pip versions will generate an 
-# error if the environment contains packages with conflicting dependencies. In 
-# this case, you can add option '--sequential' to update packages sequentially, 
-# however, the lately updated package will have precedence in this case 
-# overriding the dependencies of the packages updated before.  
-# 
-# ARGUMENTS: 
+# This command update all packages to the latest versions of particular or all
+# pyenv environments excluding system. By default, pip-upgrade update all
+# outdated packages of an environment at once. New pip versions will generate an
+# error if the environment contains packages with conflicting dependencies. In
+# this case, you can add option '--sequential' to update packages sequentially,
+# however, the lately updated package will have precedence in this case
+# overriding the dependencies of the packages updated before.
+#
+# ARGUMENTS:
 #   --all - to update all environments
-# 
+#
 # OPTIONS:
 #   --sequential - update all outdated packages one by one
 
 # setting bash strict mode
-set -o errexit 
+set -o errexit
 set -o pipefail
 set -o nounset
 IFS=$'\n\t'
@@ -45,22 +45,18 @@ function __conda () {
   pyenv exec conda ${@}
 }
 
-function elementIn () {
-  local elem="$1"   # Save first argument in a variable
-  shift            # Shift all arguments to the left (original $1 gets lost)
-  local arr=("$@") # Rebuild the array with rest of arguments
-  if printf '%s\n' "${arr[@]}" | grep -q --line-regexp "${elem}"; then
-    return 0
-  fi
+function __element_in () {
+  # https://stackoverflow.com/a/8574392/2089675
+  local elem needle="$1"  # Save first argument in a variable
+  shift                   # Shift all arguments to the left (original $1 gets lost)
+  for elem; do [[ "$elem" == "$needle" ]] && return 0; done
   return 1
 }
 
 function pip_upgrade_packages () {
   # https://stackoverflow.com/a/3452888/1108213
   local outdated_packages=()
-  while IFS='' read -r line; do 
-    outdated_packages+=("$line"); 
-  done < <(__pip list --outdated --format=freeze 2>/dev/null | grep -v '^-e' | cut -d = -f 1)
+  readarray -t outdated_packages < <(__pip list --outdated --format=freeze 2>/dev/null | awk 'match($0, /^(.+?)==/, arr) {print arr[1]}')
   if [[ ${#outdated_packages[@]} -eq 0 ]]; then
     __msg_info "Nothing to update in this environment..."
     return
@@ -80,12 +76,10 @@ function pip_upgrade_packages () {
 # --bare - allows to skip system installation
 # --skip-aliases - skips environment aliases (speeding up updates by skipping aliases)
 pyenvs=()
-while IFS='' read -r line; do 
-  pyenvs+=("$line"); 
-done < <(pyenv versions --bare --skip-aliases)
+readarray -t pyenvs < <(pyenv versions --bare --skip-aliases)
 
 # Provide pyenv completions
-if [ "$1" = "--complete" ]; then
+if [ "${1:-}" = "--complete" ]; then
   echo "--all" # add '--all' as completion option
   echo "--sequential"
   echo "${pyenvs[@]}"
@@ -111,8 +105,8 @@ while [[ $# -gt 0 ]]; do
     *) # unknown option - assume that this is pyenv environment name
       # check if argument is among pyenv versions
       # if printf '%s\n' "${pyenvs[@]}" | grep -q --line-regexp "${argument}"; then
-      if elementIn "${argument}" "${pyenvs[@]}"; then
-        if ! elementIn "${argument}" "${pyenvs_to_update[@]}"; then
+      if __element_in "${argument}" "${pyenvs[@]}"; then
+        if ! __element_in "${argument}" "${pyenvs_to_update[@]}"; then
           pyenvs_to_update+=( "$argument" )
         fi
       else


### PR DESCRIPTION
Before this PR, the upgrade script was using pip from my system path, and attempting to upgrade the os-installed python packages.

This fix ensures that the correct `pip` version corresponding to the `PYENV_VERSION` set, is being used.

### Other changes
- use gnu awk instead of combination of grep and cut
- prefer bash's readarray over read + while loop
- Fix elementIn function  to use bash primitives over grep